### PR TITLE
Add X-Customer documentation

### DIFF
--- a/source/includes/_api.auth.md
+++ b/source/includes/_api.auth.md
@@ -31,4 +31,5 @@ var vhx = require('vhx')('YOUR_API_KEY');
 <section class="text-2 contain">
   <p>API applications can be created in the <a href="https://www.vhx.tv/admin/platforms" target="_blank">VHX admin</a> or by emailing <a href="mailto:api@vhx.tv">api@vhx.tv</a>.</p>
   <p>Once your application is created, you will receive an <code>API Key</code>. All resources require authentication with this <code>API Key</code> over <a href="https://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">HTTP Basic Auth</a>. Your <code>API Key</code> acts as the basic auth username. You do not need to provide a password (but do notice the trailing <code>:</code>).</p>
+  <p>When making API calls on behalf of a customer, the <code>X-Customer</code> header with the customer <code>href</code> should be sent as part of the request. This let's the API respond with relevant information for that particular customer (like continue watching, resuming, etc).
 </section>


### PR DESCRIPTION
This adds documentation for the new `X-Customer` header. This let's API-key based requests (on behalf of a customer) set the customer they are making the call for. This allows the API to respond with customer-specific data ..like resume data!

Related:

Commit: https://github.com/vhx/crystal/pull/1920/commits/b1f13d48337417f295ae99a0d25235f2356c7993
PR: https://github.com/vhx/crystal/pull/1920
