### PR TITLE
Feature/avod

### DIFF
--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -305,10 +305,6 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
 
 <section class="text-2 contain">
   <p>Retrieves an existing video.</p>
-
-  <p>Videos that are associated with a collection will have relevant metadata automatically applied in the <code>metadata</code> property. This includes the following fields: <code>series_name</code>, <code>season_name</code>, <code>season_number</code>, <code>episode_number</code>, and <code>movie_name</code></p>
-
-  <p class="is-internal">Videos that are associated with a product that have advertising enabled will include an <code>advertising</code> property in the response. The <code>advertising</code> object contains relevant data for the Ad provider and tag url. In addition, if advertising keywords have been setup they will be returned in the <code>metadata</code> property.</p>
 </section>
 
 <table>
@@ -331,6 +327,12 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
   </tbody>
 </table>
 
+<section class="text-2 contain">
+  <strong class="block margin-top-large">Response</strong>
+  <p>Videos that are associated with a collection will have relevant metadata automatically applied in the <code>metadata</code> property. This includes the following fields: <code>series_name</code>, <code>season_name</code>, <code>season_number</code>, <code>episode_number</code>, and <code>movie_name</code></p>
+
+  <p class="is-internal">Videos that are associated with a product that have advertising enabled will include an <code>advertising</code> property in the response. The <code>advertising</code> object contains relevant data for the Ad provider and tag url. In addition, if advertising keywords have been setup they will be returned in the <code>metadata</code> property.</p>
+</section>
 
 <h3 class="text-2 head-4 text--navy text--bold is-api margin-top-large margin-bottom-medium" id="videos-list">List all Videos</h3>
 

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -301,7 +301,7 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
 
 <section class="text-2 contain">
   <p>Retrieves an existing video.</p>
-  <p class="is-internal">Videos that are associated with a product that has advertising enabled will include an <code>advertising</code> property in the response with the relevant data for the Ad provider and tag url. If advertising keywords have been setup they will be returned in the <code>metadata</code> property.</p>
+  <p class="is-internal">Videos that are associated with a product that have advertising enabled will include an <code>advertising</code> property in the response. The <code>advertising</code> object contains relevant data for the Ad provider and tag url. In addition, if advertising keywords have been setup they will be returned in the <code>metadata</code> property.</p>
 </section>
 
 <table>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -131,13 +131,7 @@ vhx.videos.create({
   "tracks": {
     "subtitles": []
   },
-  "advertising": {
-    "_links": {
-      "tag": { "href": "https://static.vhx.tv/vmap.xml" }
-    },
-    "client": "vmap",
-    "provider": "dfp"
-  },
+  "advertising": {},
   "metadata": {
     "advertising_keywords": []
   },
@@ -307,6 +301,7 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
 
 <section class="text-2 contain">
   <p>Retrieves an existing video.</p>
+  <p class="is-internal">Videos that are associated with a product that has advertising enabled will include an <code>advertising</code> property in the response with the relevant data for the Ad provider and tag url. If advertising keywords have been setup they will be returned in the <code>metadata</code> property.</p>
 </section>
 
 <table>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -291,6 +291,10 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
     "provider": "dfp"
   },
   "metadata": {
+    "series_name": "Series Name",
+    "season_name": "Season 1",
+    "season_number": 1,
+    "episode_number": 5,
     "advertising_keywords": []
   },
   "files_count": 5,
@@ -301,6 +305,9 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
 
 <section class="text-2 contain">
   <p>Retrieves an existing video.</p>
+
+  <p>Videos that are associated with a collection will have relevant metadata automatically applied in the <code>metadata</code> property. This includes the following fields: <code>series_name</code>, <code>season_name</code>, <code>season_number</code>, <code>episode_number</code>, and <code>movie_name</code></p>
+
   <p class="is-internal">Videos that are associated with a product that have advertising enabled will include an <code>advertising</code> property in the response. The <code>advertising</code> object contains relevant data for the Ad provider and tag url. In addition, if advertising keywords have been setup they will be returned in the <code>metadata</code> property.</p>
 </section>
 

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -131,6 +131,16 @@ vhx.videos.create({
   "tracks": {
     "subtitles": []
   },
+  "advertising": {
+    "_links": {
+      "tag": { "href": "https://static.vhx.tv/vmap.xml" }
+    },
+    "client": "vmap",
+    "provider": "dfp"
+  },
+  "metadata": {
+    "advertising_keywords": []
+  },
   "files_count": 0,
   "created_at": "2014-02-25T20:19:30Z",
   "updated_at": "2014-02-25T20:19:30Z"
@@ -278,6 +288,16 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
         "kind": "subtitles"
       }
     ]
+  },
+  "advertising": {
+    "_links": {
+      "tag": { "href": "https://static.vhx.tv/vmap.xml" }
+    },
+    "client": "vmap",
+    "provider": "dfp"
+  },
+  "metadata": {
+    "advertising_keywords": []
   },
   "files_count": 5,
   "created_at": "2014-02-25T20:19:30Z",


### PR DESCRIPTION
This ads the `advertising` and `metadata` properties to the example Video Create and Retrieve responses. 

In addition, a description is given for these properties in the Video Retrieve section. The description is marked as internal, so it is hidden unless the query param `internal=1` is in the URL.

cc @ksheurs I believe this is all that we currently have with regards to Advertising data in the API. yes?