### PR TITLE
Fix/metadata

### DIFF
--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -508,8 +508,7 @@ vhx.collections.update();
 ```shell
 $ curl -X PUT "https://api.vhx.tv/collections/1" \
   -H "Content-Type: application/json" \
-  -d '{"description": "A new description",
-  "metadata": {"producer": "Christoper Nolan", "director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017}}' \
+  -d '{"description": "A new description", "metadata": {"producer": "Christoper Nolan", "director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017}}' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -203,7 +203,7 @@ vhx.collections.create({
       </td>
       <td>A publicly accessible image URL. If you prefer you can upload images directly to a collection in the VHX Publisher Admin.</td>
     </tr>    
-    <tr class="text-2 border-bottom border--light-gray">
+    <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">metadata</strong>
         <span class="text--transparent text-3">optional object</span>
@@ -623,7 +623,7 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
       </td>
       <td>A publicly accessible image URL. If you prefer you can upload images directly to a collection in the VHX Publisher Admin.</td>
     </tr>
-    <tr class="text-2 border-bottom border--light-gray">
+    <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">metadata</strong>
         <span class="text--transparent text-3">optional object</span>

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -506,9 +506,10 @@ vhx.collections.update();
 > Example Request
 
 ```shell
-$ curl -X POST "https://api.vhx.tv/collections/1" \
+$ curl -X PUT "https://api.vhx.tv/collections/1" \
   -H "Content-Type: application/json" \
-  -d '{"description": "A new description", "metadata": {"producer": "Christoper Nolan" }}' \
+  -d '{"description": "A new description",
+  "metadata": {"producer": "Christoper Nolan", "director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017}}' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -516,6 +517,9 @@ $ curl -X POST "https://api.vhx.tv/collections/1" \
 collection = Vhx::Collection.retrieve("https://api.vhx.tv/collections/1").update({
   description: 'A new description',
   metadata: {
+    director: 'Brad Pitt',
+    writers: ['Foo Bar', 'Bar Foo'],
+    release_year: 2017
     producer: 'Christoper Nolan'
   }
 })
@@ -525,6 +529,9 @@ collection = Vhx::Collection.retrieve("https://api.vhx.tv/collections/1").update
 vhx.collections.update("https://api.vhx.tv/collections/1", {
   description: 'A new description',
   metadata: {
+    director: 'Brad Pitt',
+    writers: ['Foo Bar', 'Bar Foo'],
+    release_year: 2017
     producer: 'Christoper Nolan'
   }
 }, function(err, collection) {
@@ -540,6 +547,9 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
 <?php$collection = \VHX\Collections::update("https://api.vhx.tv/collections/1", array(
   'name' => 'A new description',
   'metadata' => array(
+    'director' => 'Brad Pitt',
+    'writers' => ['Foo Bar', 'Bar Foo'],
+    'release_year' => 2017,
     'producer' => 'Christoper Nolan'
   )
 ));

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -109,7 +109,12 @@ vhx.collections.create({
 ```php
 <?php$collection = \VHX\Collections::create(array(
   'name' => 'Collection Name',
-  'type' => 'series'
+  'type' => 'series',
+  'metadata' => array(
+    'director' => 'Brad Pitt',
+    'writers' => ['Foo Bar', 'Bar Foo'],
+    'release_year' => 2017
+  )
 ));
 ```
 

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -80,7 +80,7 @@ $ curl -X POST "https://api.vhx.tv/collections" \
 collection = Vhx::Collection.create({
   name: 'Collection Name',
   type: 'series',
-  metadata: { 
+  metadata: {
     director: 'Brad Pitt',
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017
@@ -92,7 +92,7 @@ collection = Vhx::Collection.create({
 vhx.collections.create({
   name: 'Collection Name',
   type: 'series',
-  metadata: { 
+  metadata: {
     director: 'Brad Pitt',
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017
@@ -508,17 +508,15 @@ vhx.collections.update();
 ```shell
 $ curl -X POST "https://api.vhx.tv/collections/1" \
   -H "Content-Type: application/json" \
-  -d '{"description": "A new description", "metadata": {"director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017}}' \
+  -d '{"description": "A new description", "metadata": {"producer": "Christoper Nolan" }}' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
 ```ruby
 collection = Vhx::Collection.retrieve("https://api.vhx.tv/collections/1").update({
   description: 'A new description',
-  metadata: { 
-    director: 'Brad Pitt',
-    writers: ['Foo Bar', 'Bar Foo'],
-    release_year: 2017
+  metadata: {
+    producer: 'Christoper Nolan'
   }
 })
 ```
@@ -526,10 +524,8 @@ collection = Vhx::Collection.retrieve("https://api.vhx.tv/collections/1").update
 ```node
 vhx.collections.update("https://api.vhx.tv/collections/1", {
   description: 'A new description',
-  metadata: { 
-    director: 'Brad Pitt',
-    writers: ['Foo Bar', 'Bar Foo'],
-    release_year: 2017
+  metadata: {
+    producer: 'Christoper Nolan'
   }
 }, function(err, collection) {
   // asynchronously called
@@ -542,7 +538,10 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
 
 ```php
 <?php$collection = \VHX\Collections::update("https://api.vhx.tv/collections/1", array(
-  'name' => 'A new description'
+  'name' => 'A new description',
+  'metadata' => array(
+    'producer' => 'Christoper Nolan'
+  )
 ));
 ```
 
@@ -576,6 +575,7 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
   },
   "metadata": {
     "director": "Brad Pitt",
+    "producer": "Christoper Nolan",
     "writers": ["Foo Bar", "Bar Foo"],
     "release_year": 2017
   },

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -78,7 +78,7 @@ video = Vhx::Video.create({
   title: 'My Video',
   description: 'My video description.',
   source_url: 's3:://YOUR_BUCKET_NAME/FILE.mp4',
-  metadata: { 
+  metadata: {
     director: 'Brad Pitt',
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017
@@ -91,7 +91,7 @@ vhx.videos.create({
   title: 'My Video',
   description: 'My video description.',
   source_url: 's3:://YOUR_BUCKET_NAME/FILE.mp4',
-  metadata: { 
+  metadata: {
     director: 'Brad Pitt',
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017
@@ -614,17 +614,15 @@ vhx.videos.update();
 ```shell
 $ curl -X POST "https://api.vhx.tv/videos/1" \
   -H "Content-Type: application/json" \
-  -d '{"description":"My video description.", "metadata": {"director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017}}' \
+  -d '{"description":"My video description.", "metadata": {"producer": "Christopher Nolan" }' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
 ```ruby
 video = Vhx::Video.retrieve("https://api.vhx.tv/videos/1").update({
   description: 'A new description',
-  metadata: { 
-    director: 'Brad Pitt',
-    writers: ['Foo Bar', 'Bar Foo'],
-    release_year: 2017
+  metadata: {
+    producer: 'Christoper Nolan'
   }
 })
 ```
@@ -632,10 +630,8 @@ video = Vhx::Video.retrieve("https://api.vhx.tv/videos/1").update({
 ```node
 vhx.videos.update("https://api.vhx.tv/videos/1", {
   description: 'A new description',
-  metadata: { 
-    director: 'Brad Pitt',
-    writers: ['Foo Bar', 'Bar Foo'],
-    release_year: 2017
+  metadata: {
+    producer: 'Christoper Nolan'
   }
 }, function(err, video) {
   // asynchronously called
@@ -648,7 +644,10 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
 
 ```php
 <?php$video = \VHX\Videos::update("https://api.vhx.tv/videos/1", array(
-  'name' => 'A new description'
+  'name' => 'A new description',
+  'metadata' => array(
+    'producer' => 'Christoper Nolan'
+  )
 ));
 ```
 
@@ -683,6 +682,7 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
   "advertising": {},
   "metadata": {
     "director": "Brad Pitt",
+    "producer": "Christoper Nolan",
     "writers": ["Foo Bar", "Bar Foo"],
     "release_year": 2017,
     "advertising_keywords": []

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -109,7 +109,12 @@ vhx.videos.create({
 <?php$video = \VHX\Videos::create(array(
   'title' => 'My Video',
   'description' => 'My video description.',
-  'source_url' => 's3:://YOUR_BUCKET_NAME/FILE.mp4'
+  'source_url' => 's3:://YOUR_BUCKET_NAME/FILE.mp4',
+  'metadata' => array(
+    'director' => 'Brad Pitt',
+    'writers' => ['Foo Bar', 'Bar Foo'],
+    'release_year' => 2017
+  )
 ));
 ```
 > Example Response

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -583,7 +583,7 @@ vhx.videos.files({
 </section>
 
 <h3 class="text-2 head-4 text--navy text--bold is-api margin-top-large margin-bottom-medium"
-id="collections-update">Update a Video</h3>
+id="videos-update">Update a Video</h3>
 
 > <h5 class="head-5 text--white margin-bottom-medium">Update a Video</h5>
 

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -193,8 +193,8 @@ vhx.videos.create({
       </td>
       <td>A description for the video.</p></td>
     </tr>
-  
-    <tr class="text-2 border-bottom border--light-gray">
+
+    <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">metadata</strong>
         <span class="text--transparent text-3">object of key value pairs</span>
@@ -720,7 +720,7 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
       </td>
       <td>A description for the video.</p></td>
     </tr>
-    <tr class="text-2 border-bottom border--light-gray">
+    <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">metadata</strong>
         <span class="text--transparent text-3">object of key value pairs</span>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -614,7 +614,7 @@ vhx.videos.update();
 ```shell
 $ curl -X POST "https://api.vhx.tv/videos/1" \
   -H "Content-Type: application/json" \
-  -d '{"description":"My video description.", "metadata": {"producer": "Christopher Nolan" }' \
+  -d '{"description":"My video description.", "metadata": {"producer": "Christoper Nolan", "director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017}}' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -622,6 +622,9 @@ $ curl -X POST "https://api.vhx.tv/videos/1" \
 video = Vhx::Video.retrieve("https://api.vhx.tv/videos/1").update({
   description: 'A new description',
   metadata: {
+    director: 'Brad Pitt',
+    writers: ['Foo Bar', 'Bar Foo'],
+    release_year: 2017
     producer: 'Christoper Nolan'
   }
 })
@@ -631,6 +634,9 @@ video = Vhx::Video.retrieve("https://api.vhx.tv/videos/1").update({
 vhx.videos.update("https://api.vhx.tv/videos/1", {
   description: 'A new description',
   metadata: {
+    director: 'Brad Pitt',
+    writers: ['Foo Bar', 'Bar Foo'],
+    release_year: 2017
     producer: 'Christoper Nolan'
   }
 }, function(err, video) {
@@ -646,6 +652,9 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
 <?php$video = \VHX\Videos::update("https://api.vhx.tv/videos/1", array(
   'name' => 'A new description',
   'metadata' => array(
+    'director' => 'Brad Pitt',
+    'writers' => ['Foo Bar', 'Bar Foo'],
+    'release_year' => 2017,
     'producer' => 'Christoper Nolan'
   )
 ));

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -811,4 +811,8 @@ header {
   [data-unique="authentication-oauth-customer"] {
     display: block !important;
   }
+
+  tr.is-internal {
+    display: table-row !important;
+  }
 }


### PR DESCRIPTION
Adds PHP examples to docs, makes update requests clear with metadata, fixes bug with videos-update hash, makes metadata descriptions internal where we can at the moment.