### PR TITLE
Add plans to videos, collections, customers (VHX-252)

### DIFF
--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -73,7 +73,8 @@ vhx.collections.create();
 $ curl -X POST "https://api.vhx.tv/collections" \
   -H "Content-Type: application/json" \
   -d '{"name": "Collection Name", "type": "series", "metadata": {"director": "Brad Pitt", "writers":
-["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon": "image_url:https://vhx.imgix.net/site/assets/1231.jpg"}}' \
+["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon":
+"image_url:https://vhx.imgix.net/site/assets/1231.jpg"}, "plans": ["public", "free", "standard"]}' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -86,7 +87,8 @@ collection = Vhx::Collection.create({
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017,
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg",
-  }
+  },
+  plans: ["public", "free", "standard"]
 })
 ```
 
@@ -99,7 +101,8 @@ vhx.collections.create({
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017,
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg"
-  }
+  },
+  plans: ["public", "free", "standard"]
 }, function(err, collection) {
   // asynchronously called
 });
@@ -118,7 +121,8 @@ vhx.collections.create({
     'writers' => ['Foo Bar', 'Bar Foo'],
     'release_year' => 2017,
     'custom_icon' => 'image_url:https://vhx.imgix.net/site/assets/1231.jpg'
-  )
+  ),
+  'plans' => ['public', 'free', 'standard']
 ));
 ```
 
@@ -161,6 +165,7 @@ vhx.collections.create({
       "source": "https://vhx.imgix.net/site/assets/1231.jpg"
     },
   },
+  "plans": ["public", "free", "standard"],
   "type": "series",
   "seasons_count": 0,
   "items_count": 0,
@@ -227,6 +232,24 @@ vhx.collections.create({
 
       Metadata values can be strings, integers, arrays, or images. An image metadata value
       must must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>. 
+      </td>
+    </tr>
+    <tr class="is-internal text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">plans</strong>
+        <span class="text--transparent text-3">array of strings</span>
+      </td>
+      <td>
+      An array of plan types that you can use to set video availability. 
+      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+
+      The `"public"` plan makes the video object available for free, without registration to any public
+      visitor to your site.<br><br>
+      
+      The `"free"` plan makes the video object available for free, but requires user email
+      registration<br><br>
+
+      The `"standard"` plan makes the video object available to paying subscribers.
       </td>
     </tr>
   </tbody>
@@ -315,6 +338,7 @@ vhxjs.collections.retrieve("https://api.vhx.tv/collections/1", function(err, col
       "source": "https://vhx.imgix.net/site/assets/1231.jpg"
     },
   },
+  "plans": ["public", "free", "standard"],
   "type": "category",
   "items_count": 10,
   "created_at": "2014-02-25T20:19:30Z",
@@ -531,7 +555,8 @@ vhx.collections.update();
 $ curl -X PUT "https://api.vhx.tv/collections/1" \
   -H "Content-Type: application/json" \
   -d '{"description": "A new description", "metadata": {"producer": "Christoper Nolan", "director":
-"Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon": "image_url:https://vhx.imgix.net/site/assets/1231.jpg"}}' \
+"Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon":
+"image_url:https://vhx.imgix.net/site/assets/1231.jpg"}, "plans": ["public", "free", "standard"] }' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -544,7 +569,8 @@ collection = Vhx::Collection.retrieve("https://api.vhx.tv/collections/1").update
     release_year: 2017
     producer: 'Christoper Nolan',
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg",
-  }
+  },
+  plans: ["public", "free", "standard"]
 })
 ```
 
@@ -557,7 +583,8 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
     release_year: 2017
     producer: 'Christoper Nolan',
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg"
-  }
+  },
+  plans: ["public", "free", "standard"]
 }, function(err, collection) {
   // asynchronously called
 });
@@ -577,6 +604,7 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
     'producer' => 'Christoper Nolan',
     'custom_icon' => 'image_url:https://vhx.imgix.net/site/assets/1231.jpg'
   )
+  'plans' => ['public', 'free', 'standard'],
 ));
 ```
 
@@ -620,6 +648,7 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
       "source": "https://vhx.imgix.net/site/assets/1231.jpg"
     },
   },
+  "plans": ["public", "free", "standard"],
   "type": "series",
   "seasons_count": 0,
   "items_count": 0,
@@ -678,6 +707,24 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
 
       Metadata values can be strings, integers, arrays, or images. An image metadata value
       must must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>. 
+      </td>
+    </tr>
+    <tr class="is-internal text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">plans</strong>
+        <span class="text--transparent text-3">array of strings</span>
+      </td>
+      <td>
+      An array of plan types that you can use to set video availability. 
+      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+
+      The `"public"` plan makes the video object available for free, without registration to any public
+      visitor to your site.<br><br>
+      
+      The `"free"` plan makes the video object available for free, but requires user email
+      registration<br><br>
+
+      The `"standard"` plan makes the video object available to paying subscribers.
       </td>
     </tr>
   </tbody>

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -240,16 +240,17 @@ vhx.collections.create({
         <span class="text--transparent text-3">array of strings</span>
       </td>
       <td>
-      An array of plan types that you can use to set video availability. 
-      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+      An array of plan types that you can use to set collection availability. 
+      Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
+      <code>standard</code>.<br><br>
 
-      The `"public"` plan makes the video object available for free, without registration to any public
-      visitor to your site.<br><br>
+      The <code>public</code> plan makes the collection object available for free, without registration 
+      to any public visitor to your site.<br><br>
       
-      The `"free"` plan makes the video object available for free, but requires user email
+      The <code>free</code> plan makes the collection object available for free, but requires user email
       registration<br><br>
 
-      The `"standard"` plan makes the video object available to paying subscribers.
+      The <code>standard</code> plan makes the collection object available to paying subscribers.
       </td>
     </tr>
   </tbody>
@@ -715,16 +716,17 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
         <span class="text--transparent text-3">array of strings</span>
       </td>
       <td>
-      An array of plan types that you can use to set video availability. 
-      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+      An array of plan types that you can use to set collection availability. 
+      Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
+      <code>standard</code>.<br><br>
 
-      The `"public"` plan makes the video object available for free, without registration to any public
-      visitor to your site.<br><br>
+      The <code>public</code> plan makes the collection object available for free, without registration 
+      to any public visitor to your site.<br><br>
       
-      The `"free"` plan makes the video object available for free, but requires user email
+      The <code>free</code> plan makes the collection object available for free, but requires user email
       registration<br><br>
 
-      The `"standard"` plan makes the video object available to paying subscribers.
+      The <code>standard</code> plan makes the collection object available to paying subscribers.
       </td>
     </tr>
   </tbody>

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -244,8 +244,8 @@ vhx.collections.create({
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
       <code>standard</code>.<br><br>
 
-      The <code>public</code> plan makes the collection object available for free, without registration 
-      to any public visitor to your site.<br><br>
+      The <code>public</code> plan makes the collection object available without email 
+      registration or paid subscription.<br><br>
       
       The <code>free</code> plan makes the collection object available for free, but requires user email
       registration<br><br>
@@ -720,8 +720,8 @@ vhx.collections.update("https://api.vhx.tv/collections/1", {
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
       <code>standard</code>.<br><br>
 
-      The <code>public</code> plan makes the collection object available for free, without registration 
-      to any public visitor to your site.<br><br>
+      The <code>public</code> plan makes the collection object available without email 
+      registration or paid subscription.<br><br>
       
       The <code>free</code> plan makes the collection object available for free, but requires user email
       registration<br><br>

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -410,18 +410,21 @@ vhxjs.collections.all();
 ```shell
 $ curl -X GET -G "https://api.vhx.tv/collections" \
   -d product=https://api.vhx.tv/products/1 \
+  -d plan=standard
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
 ```ruby
 collections = Vhx::Collection.all({
-  product: 'https://api.vhx.tv/products/1'
+  product: 'https://api.vhx.tv/products/1',
+  plan: 'standard'
 })
 ```
 
 ```node
 vhx.collections.all({
-  product: 'https://api.vhx.tv/products/1'
+  product: 'https://api.vhx.tv/products/1',
+  plan: 'standard'
 }, function(err, collections) {
   // asynchronously called
 });
@@ -429,7 +432,8 @@ vhx.collections.all({
 
 ```javascript
 vhxjs.collections.all({
-  product: 'https://api.vhx.tv/products/1'
+  product: 'https://api.vhx.tv/products/1',
+  plan: 'standard'
 }, function(err, collections) {
   // asynchronously called
 });
@@ -437,7 +441,8 @@ vhxjs.collections.all({
 
 ```php
 <?php$collections = \VHX\Collections::all(array(
-  'product' => 'https://api.vhx.tv/products/1'
+  'product' => 'https://api.vhx.tv/products/1',
+  'plan' => 'standard'
 ));
 ```
 
@@ -446,11 +451,11 @@ vhxjs.collections.all({
 ```json
 {
   "_links": {
-    "self":  { "href": "https://api.vhx.tv/collections?page=1&product=:href" },
-    "first": { "href": "https://api.vhx.tv/collections?product=:href" },
+    "self":  { "href": "https://api.vhx.tv/collections?page=1&product=:href&plan=standard" },
+    "first": { "href": "https://api.vhx.tv/collections?product=:href&plan=standard" },
     "prev":  { "href": null },
-    "next":  { "href": "https://api.vhx.tv/collections?page=2&product=:href" },
-    "last":  { "href": "https://api.vhx.tv/collections?page=5&product=:href" }
+    "next":  { "href": "https://api.vhx.tv/collections?page=2&product=:href&plan=standard" },
+    "last":  { "href": "https://api.vhx.tv/collections?page=5&product=:href&plan=standard" }
   },
   "count": 100,
   "total": 500,
@@ -496,6 +501,14 @@ vhxjs.collections.all({
         <span class="text--transparent text-3">optional</span>
       </td>
       <td>The query to search and filter the paginated results.</td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">plan</strong>
+        <span class="is-block text--transparent text-3">string</span>
+        <span class="text--transparent text-3">optional</span>
+      </td>
+      <td>The plan(s) to filter the paginated results. The value can be an array or comma separated string.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
       <td>

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -502,7 +502,7 @@ vhxjs.collections.all({
       </td>
       <td>The query to search and filter the paginated results.</td>
     </tr>
-    <tr class="text-2 border-bottom border--light-gray">
+    <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">plan</strong>
         <span class="is-block text--transparent text-3">string</span>

--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -141,10 +141,10 @@ vhx.customers.create({
       <td class="nowrap">
         <strong class="is-block text--navy">plan</strong>
         <span class="is-block text--transparent text-3">string</span>
-        <span class="text--transparent text-3">optional</span>
+        <span class="text--transparent text-3">optional, default is "standard"</span>
       </td>
       <td>
-      The tier of content the customer will be able to access. Values can be one of
+      The customer's plan determines content accessibility. Values can be one of
       the following strings: `free`, `standard`. 
       See <a href="#videos-update">Update Video</a> for more detail on the types of plans</td>
     </tr>

--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -137,7 +137,7 @@ vhx.customers.create({
       </td>
       <td>Billing parameters for <a href="/in-app-purchases">In-App Purchases</a> for the Apple, Google, and Roku platforms.</td>
     </tr>
-    <tr class="text-2 border-bottom border--light-gray">
+    <tr class="is-internal text-2 border-bottom border--light-gray">
       <td class="nowrap">
         <strong class="is-block text--navy">plan</strong>
         <span class="is-block text--transparent text-3">string</span>
@@ -145,7 +145,7 @@ vhx.customers.create({
       </td>
       <td>
       The customer's plan determines content accessibility. Values can be one of
-      the following strings: `free`, `standard`. 
+      the following strings: <code>free</code>, <code>standard</code>. 
       See <a href="#videos-update">Update Video</a> for more detail on the types of plans</td>
     </tr>
   </tbody>

--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -38,22 +38,25 @@ $ curl -X POST "https://api.vhx.tv/customers" \
   -d name="First Last" \
   -d email="customer@email.com" \
   -d product="https://api.vhx.tv/products/1" \
+  -d plan="standard" \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
 ```ruby
 customer = Vhx::Customer.create({
   name: 'First Last',
-  email: 'customer@email.com'
-  product: 'https://api.vhx.tv/products/1'
+  email: 'customer@email.com',
+  product: 'https://api.vhx.tv/products/1',
+  plan: 'standard'
 })
 ```
 
 ```node
 vhx.customers.create({
   name: 'First Last',
-  email: 'customer@email.com'
-  product: 'https://api.vhx.tv/products/1'
+  email: 'customer@email.com',
+  product: 'https://api.vhx.tv/products/1',
+  plan: 'standard'
 }, function(err, customer) {
   // asynchronously called
 });
@@ -67,7 +70,8 @@ vhx.customers.create({
 <?php$customer = \VHX\Customers::create(array(
   'name' => 'First Last',
   'email' => 'customer@email.com',
-  'product' => 'https://api.vhx.tv/products/1'
+  'product' => 'https://api.vhx.tv/products/1',
+  'plan' => 'standard'
 ));
 ```
 
@@ -83,7 +87,8 @@ vhx.customers.create({
   "name": "First Last",
   "email": "customer@email.com",
   "created_at": "2014-02-25T20:19:30Z",
-  "updated_at": "2014-02-25T20:19:30Z"
+  "updated_at": "2014-02-25T20:19:30Z",
+  "plan": "standard"
 }
 ```
 
@@ -131,6 +136,16 @@ vhx.customers.create({
         <span class="text--transparent text-3">optional</span>
       </td>
       <td>Billing parameters for <a href="/in-app-purchases">In-App Purchases</a> for the Apple, Google, and Roku platforms.</td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td class="nowrap">
+        <strong class="is-block text--navy">plan</strong>
+        <span class="is-block text--transparent text-3">string</span>
+      </td>
+      <td>
+      The tier of content the customer will be able to access. Values can be one of
+      the following strings: `"free"`, `"standard"`. 
+      See <a href="#videos-update">Update Video</a>for more detail on the types of plans</td>
     </tr>
   </tbody>
 </table>
@@ -202,7 +217,8 @@ vhxjs.customers.retrieve("https://api.vhx.tv/customers/1", function(err, custome
   "name": "First Last",
   "email": "customer@email.com",
   "created_at": "2014-02-25T20:19:30Z",
-  "updated_at": "2014-02-25T20:19:30Z"
+  "updated_at": "2014-02-25T20:19:30Z",
+  "plan": "standard"
 }
 ```
 <section class="text-2 contain margin-bottom-medium">

--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -144,7 +144,7 @@ vhx.customers.create({
       </td>
       <td>
       The tier of content the customer will be able to access. Values can be one of
-      the following strings: `"free"`, `"standard"`. 
+      the following strings: `free`, `standard`. 
       See <a href="#videos-update">Update Video</a>for more detail on the types of plans</td>
     </tr>
   </tbody>

--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -141,11 +141,12 @@ vhx.customers.create({
       <td class="nowrap">
         <strong class="is-block text--navy">plan</strong>
         <span class="is-block text--transparent text-3">string</span>
+        <span class="text--transparent text-3">optional</span>
       </td>
       <td>
       The tier of content the customer will be able to access. Values can be one of
       the following strings: `free`, `standard`. 
-      See <a href="#videos-update">Update Video</a>for more detail on the types of plans</td>
+      See <a href="#videos-update">Update Video</a> for more detail on the types of plans</td>
     </tr>
   </tbody>
 </table>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -237,15 +237,16 @@ vhx.videos.create({
       </td>
       <td>
       An array of plan types that you can use to set video availability. 
-      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+      Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
+      <code>standard</code>.<br><br>
 
-      The `"public"` plan makes the video object available for free, without registration to any public
-      visitor to your site.<br><br>
+      The <code>public</code> plan makes the video object available for free, without registration 
+      to any public visitor to your site.<br><br>
       
-      The `"free"` plan makes the video object available for free, but requires user email
+      The <code>free</code> plan makes the video object available for free, but requires user email
       registration<br><br>
 
-      The `"standard"` plan makes the video object available to paying subscribers.
+      The <code>standard</code> plan makes the video object available to paying subscribers.
       </td>
     </tr>
   </tbody>
@@ -818,15 +819,16 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
       </td>
       <td>
       An array of plan types that you can use to set video availability. 
-      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+      Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
+      <code>standard</code>.<br><br>
 
-      The `"public"` plan makes the video object available for free, without registration to any public
-      visitor to your site.<br><br>
+      The <code>public</code> plan makes the video object available for free, without registration 
+      to any public visitor to your site.<br><br>
       
-      The `"free"` plan makes the video object available for free, but requires user email
+      The <code>free</code> plan makes the video object available for free, but requires user email
       registration<br><br>
 
-      The `"standard"` plan makes the video object available to paying subscribers.
+      The <code>standard</code> plan makes the video object available to paying subscribers.
       </td>
     </tr>
   </tbody>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -447,18 +447,21 @@ vhxjs.videos.all();
 ```shell
 $ curl -X GET -G "https://api.vhx.tv/videos" \
   -d query="term" \
+  -d plan="standard" \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
 ```ruby
 video = Vhx::Video.all({
-  query: 'term'
+  query: 'term',
+  plan: 'standard'
 })
 ```
 
 ```node
 vhx.videos.all({
-  query: 'term'
+  query: 'term',
+  plan: 'standard'
 }, function(err, videos) {
    // asynchronously called
 });
@@ -466,7 +469,8 @@ vhx.videos.all({
 
 ```javascript
 vhxjs.videos.all({
-  query: 'term'
+  query: 'term',
+  plan: 'standard'
 }, function(err, videos) {
    // asynchronously called
 });
@@ -474,7 +478,8 @@ vhxjs.videos.all({
 
 ```php
 <?php$videos = \VHX\Videos::all(array(
-  'query' => 'term'
+  'query' => 'term',
+  'plan' => 'standard'
 ));
 ```
 
@@ -483,11 +488,11 @@ vhxjs.videos.all({
 ```json
 {
   "_links": {
-    "self":  { "href": "https://api.vhx.tv/videos?page=1&query=term" },
-    "first": { "href": "https://api.vhx.tv/videos?query=term" },
+    "self":  { "href": "https://api.vhx.tv/videos?page=1&query=term&plan=standard" },
+    "first": { "href": "https://api.vhx.tv/videos?query=term&plan=standard" },
     "prev":  { "href": null },
-    "next":  { "href": "https://api.vhx.tv/videos?page=2&query=term" },
-    "last":  { "href": "https://api.vhx.tv/videos?page=5&query=term" }
+    "next":  { "href": "https://api.vhx.tv/videos?page=2&query=term&plan=standard" },
+    "last":  { "href": "https://api.vhx.tv/videos?page=5&query=term&plan=standard" }
   },
   "count": 100,
   "total": 500,
@@ -517,6 +522,15 @@ vhxjs.videos.all({
         <span class="text--transparent text-3">optional</span>
       </td>
       <td>The query to search and filter the paginated results.</td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">plan</strong>
+        <span class="is-block text--transparent text-3">string</span>
+        <span class="text--transparent text-3">optional</span>
+      </td>
+      <td>The plan(s) to filter the paginated results. The value can be an array or comma separated
+string. </td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
       <td>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -71,7 +71,8 @@ $ curl -X POST "https://api.vhx.tv/videos" \
   -H "Content-Type: application/json" \
   -d '{"title":"My Video","description":"My video description.",
 "source_url":"s3:://YOUR_BUCKET_NAME/FILE.mp4", "metadata": {"director": "Brad Pitt", "writers":
-["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon": "image_url:https://vhx.imgix.net/site/assets/1231.jpg"}}' \
+["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon":
+"image_url:https://vhx.imgix.net/site/assets/1231.jpg"}, "plans": ["public", "free", "standard"]}' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -85,7 +86,8 @@ video = Vhx::Video.create({
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017,
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg",
-  }
+  },
+  plans: ['public', 'free', 'standard']
 })
 ```
 
@@ -99,7 +101,8 @@ vhx.videos.create({
     writers: ['Foo Bar', 'Bar Foo'],
     release_year: 2017,
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg"
-  }
+  },
+  plans: ['public', 'free', 'standard']
 }, function(err, video) {
    // asynchronously called
 });
@@ -119,7 +122,8 @@ vhx.videos.create({
     'writers' => ['Foo Bar', 'Bar Foo'],
     'release_year' => 2017,
     'custom_icon' => 'image_url:https://vhx.imgix.net/site/assets/1231.jpg'
-  )
+  ),
+  'plans' => ['public', 'free', 'standard']
 ));
 ```
 > Example Response
@@ -163,6 +167,7 @@ vhx.videos.create({
     },
     "advertising_keywords": []
   },
+  "plans": ["public", "free", "standard"],
   "files_count": 0,
   "created_at": "2014-02-25T20:19:30Z",
   "updated_at": "2014-02-25T20:19:30Z"
@@ -222,6 +227,25 @@ vhx.videos.create({
 
       Metadata values can be strings, integers, arrays, or images. An image metadata value must 
       must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>. 
+      </td>
+    </tr>
+
+    <tr class="is-internal text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">plans</strong>
+        <span class="text--transparent text-3">array of strings</span>
+      </td>
+      <td>
+      An array of plan types that you can use to set video availability. 
+      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+
+      The `"public"` plan makes the video object available for free, without registration to any public
+      visitor to your site.<br><br>
+      
+      The `"free"` plan makes the video object available for free, but requires user email
+      registration<br><br>
+
+      The `"standard"` plan makes the video object available to paying subscribers.
       </td>
     </tr>
   </tbody>
@@ -354,6 +378,7 @@ vhxjs.videos.retrieve("https://api.vhx.tv/videos/1", function(err, video) {
     },
     "advertising_keywords": []
   },
+  "plans": ["public", "free", "standard"],
   "files_count": 5,
   "created_at": "2014-02-25T20:19:30Z",
   "updated_at": "2014-02-25T20:19:30Z"
@@ -638,7 +663,9 @@ vhx.videos.update();
 ```shell
 $ curl -X PUT "https://api.vhx.tv/videos/1" \
   -H "Content-Type: application/json" \
-  -d '{"description":"My video description.", "metadata": {"producer": "Christoper Nolan", "director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon": "image_url:https://vhx.imgix.net/site/assets/1231.jpg"}}' \
+  -d '{"description":"My video description.", "metadata": {"producer": "Christoper Nolan",
+"director": "Brad Pitt", "writers": ["Foo Bar", "Bar Foo"], "release_year": 2017, "custom_icon":
+"image_url:https://vhx.imgix.net/site/assets/1231.jpg"}, "plans": ["public", "free", "standard"]}' \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -651,7 +678,8 @@ video = Vhx::Video.retrieve("https://api.vhx.tv/videos/1").update({
     release_year: 2017,
     producer: 'Christoper Nolan',
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg",
-  }
+  },
+  plans: ["public", "free", "standard"],
 })
 ```
 
@@ -664,7 +692,8 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
     release_year: 2017,
     producer: 'Christoper Nolan',
     custom_icon: "image_url:https://vhx.imgix.net/site/assets/1231.jpg"
-  }
+  },
+  plans: ["public", "free", "standard"],
 }, function(err, video) {
   // asynchronously called
 });
@@ -682,7 +711,8 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
     'writers' => ['Foo Bar', 'Bar Foo'],
     'release_year' => 2017,
     'producer' => 'Christoper Nolan'
-  )
+  ),
+  'plans' => ['public', 'free', 'standard']
 ));
 ```
 
@@ -728,6 +758,7 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
     },
     "advertising_keywords": []
   },
+  "plans": ["public", "free", "standard"],
   "files_count": 0,
   "created_at": "2014-02-25T20:19:30Z",
   "updated_at": "2014-02-25T20:19:30Z"
@@ -778,6 +809,24 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
 
       Metadata values can be strings, integers, arrays, or images. An image metadata value must 
       must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>. 
+      </td>
+    </tr>
+    <tr class="is-internal text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">plans</strong>
+        <span class="text--transparent text-3">array of strings</span>
+      </td>
+      <td>
+      An array of plan types that you can use to set video availability. 
+      Values can be one or more of the following strings: `"public"`, `"free"`, `"standard"`.<br><br>
+
+      The `"public"` plan makes the video object available for free, without registration to any public
+      visitor to your site.<br><br>
+      
+      The `"free"` plan makes the video object available for free, but requires user email
+      registration<br><br>
+
+      The `"standard"` plan makes the video object available to paying subscribers.
       </td>
     </tr>
   </tbody>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -523,7 +523,7 @@ vhxjs.videos.all({
       </td>
       <td>The query to search and filter the paginated results.</td>
     </tr>
-    <tr class="text-2 border-bottom border--light-gray">
+    <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">plan</strong>
         <span class="is-block text--transparent text-3">string</span>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -240,8 +240,8 @@ vhx.videos.create({
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
       <code>standard</code>.<br><br>
 
-      The <code>public</code> plan makes the video object available for free, without registration 
-      to any public visitor to your site.<br><br>
+      The <code>public</code> plan makes the video object available without email 
+      registration or paid subscription.<br><br>
       
       The <code>free</code> plan makes the video object available for free, but requires user email
       registration<br><br>
@@ -822,8 +822,8 @@ vhx.videos.update("https://api.vhx.tv/videos/1", {
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
       <code>standard</code>.<br><br>
 
-      The <code>public</code> plan makes the video object available for free, without registration 
-      to any public visitor to your site.<br><br>
+      The <code>public</code> plan makes the video object available without email 
+      registration or paid subscription.<br><br>
       
       The <code>free</code> plan makes the video object available for free, but requires user email
       registration<br><br>


### PR DESCRIPTION
This PR adds Plans documentation to the `videos`, `collections`, and `customers` resources.

Plans on customers has been exposed in this PR:
https://github.com/vhx/crystal/pull/2765 (merged)

Adding standard plan to `POST /customers` was added in this PR:
https://github.com/vhx/crystal/pull/2770/files (merged)

Adding `plans` to videos and collections is being added in this PR:
https://github.com/vhx/crystal/pull/2783/files (merged)