### PR TITLE
Adjust php example request for all products request

### DIFF
--- a/source/includes/_resource.products.md
+++ b/source/includes/_resource.products.md
@@ -174,9 +174,9 @@ vhxjs.products.all({
 ```
 
 ```php
-<?php$products = \VHX\Products::all({
+<?php$products = \VHX\Products::all(array(
   'query' => 'term'
-});
+));
 ```
 
 > Example Response


### PR DESCRIPTION
Adjusting syntax for arguments on PHP client. Argument should be an array type