### PR TITLE
Clean up existing resources

### DIFF
--- a/source/includes/_resource.analytics.md
+++ b/source/includes/_resource.analytics.md
@@ -2,7 +2,7 @@
 <h2 class="head-3 margin-top-xlarge padding-top-xlarge border-top margin-bottom-medium" id="analytics">Analytics</h2>
 
 <section class="text-2 contain">
-  <p>Analytics give you access to data around your videos, customers, traffic, and platform income. You can gain insights on what your customers are watching, how many people are visiting your channel, the number of units you are selling, how many customers are subscribing and unsubscribing, and more via reports that can be easily retrieved from the VHX API.</p>
+  <p>Analytics give you access to data around your videos, customers, traffic, and platform income. You can gain insights on what your customers are watching, how many people are visiting your channel, the number of units you are selling, how many customers are subscribing and unsubscribing, and more via reports that can be easily retrieved from the Vimeo OTT API.</p>
 </section>
 
 <h3 class="text-2 head-4 text--navy text--bold is-api padding-top-large margin-top-xlarge margin-bottom-medium" id="analytics-by-video">Retrieve a Report</h3>
@@ -57,29 +57,68 @@ GET /analytics
 
   <tbody>
     <tr class="text-2 border-bottom border--light-gray">
-      <td><strong>traffic</strong></td>
-      <td>Web traffic to your VHX site across various devices and browsers. This report is for web traffic only. It includes mobile browsers but does not include Branded App activity.</td>
+      <td>
+        <strong>traffic</strong>
+        <span class="is-block text--transparent text-3">Aggregate report</span>
+      </td>
+      <td>Web traffic to your Vimeo OTT site across various devices and browsers. This report is for web traffic only. It includes mobile browsers but does not include Branded App activity.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
-      <td><strong>income_statement</strong></td>
+      <td>
+        <strong>income_statement</strong>
+        <span class="is-block text--transparent text-3">Aggregate report</span>
+      </td>
       <td>Income statements are a summary of your revenue and expenses for payout periods. Income statements are generated in monthly intervals for your account.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
-      <td><strong>units</strong></td>
+      <td>
+        <strong>units</strong>
+        <span class="is-block text--transparent text-3">Both report types</span>
+      </td>
       <td>Units are the amount of TVOD (transactional video on demand) products you have sold or have been redeemed (gifts or coupons) per given period of time. Units represent products that have been bought or rented.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
-      <td><strong>subscribers</strong></td>
+      <td>
+        <strong>subscribers</strong>
+        <span class="is-block text--transparent text-3">Both report types</span>
+      </td>
       <td>Subscribers are the number of customers that are subscribed to your SVOD (subscription on demand) product per given period of time.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
-      <td><strong>churn</strong></td>
+      <td>
+        <strong>churn</strong>
+        <span class="is-block text--transparent text-3">Both report types</span>
+      </td>
       <td>Churn gives you data around how many customers have unsubscribed (either pausing or cancelling their subscription) per given time period and their reasons (if provided) for doing so.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
-      <td><strong>video</strong></td>
-      <td>Video reports give you insights on how many plays and finishes can be attributed to customers. Sub-reports include retrieving data by platform (<code>video.platforms</code>), country (<code>video.geography</code>) or by subtitles (<code>video.subtitles</code>).</td>
-    </tr>    
+      <td>
+        <strong>video</strong>
+        <span class="is-block text--transparent text-3">Both report types</span>
+      </td>
+      <td>Video reports give you insights on how many plays and finishes can be attributed to customers. The data can be filtered by using the below sub-reports.
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong>video.platforms</strong>
+        <span class="is-block text--transparent text-3">Aggregate report</span>
+      </td>
+      <td>Video platform returns play data segmented by platform.</td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong>video.geography</strong>
+        <span class="is-block text--transparent text-3">Both report types</span>
+      </td>
+      <td>Video geography returns play data segmented by country.</td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong>video.subtitles</strong>
+        <span class="is-block text--transparent text-3">Both report types</span>
+      </td>
+      <td>Video subtitles returns play data segmented by subtitles.</td>
+    </tr>
   </tbody>
 </table>
 
@@ -112,7 +151,7 @@ GET /analytics
         <span class="is-block text--transparent text-3">string</span>
         <span class="text--transparent text-3">optional, defaults is null</span>
       </td>
-      <td>Presence of the <code>by</code> parameter implies a request for a <strong>Time Series</strong> report. If no <code>by</code> parameter is supplied an <strong>Aggregate Report</strong> will be returned. Acceptable values include <code>hour</code>, <code>day</code>, <code>week</code>, <code>month</code> or <code>year</code>.</td>
+      <td>Presence of the <code>by</code> parameter implies a request for a <strong>Time Series</strong> report. If no <code>by</code> parameter is supplied, an <strong>Aggregate Report</strong> will be returned. Acceptable values include <code>hour</code>, <code>day</code>, <code>week</code>, <code>month</code> or <code>year</code>.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
       <td class="nowrap">

--- a/source/includes/_resource.authorizations.md
+++ b/source/includes/_resource.authorizations.md
@@ -3,7 +3,7 @@
 
 <section class="text-2 contain">
   <p>An authorization grants playback access for a given customer and video.</p>
-  <p>The response includes an expiring token that is used to authenticate the VHX player on the customers behalf. This enables a customer-to-video playback session which feeds into video analytics.</p>
+  <p>The response includes an expiring token that is used to authenticate the Vimeo OTT player on the customers behalf. This enables a customer-to-video playback session which feeds into video analytics.</p>
 </section>
 
 <h3 class="text-2 head-4 text--navy text--bold is-api margin-top-large margin-bottom-medium" id="authorizations-create">Create an Authorization</h3>
@@ -20,8 +20,8 @@ POST /authorizations
 
 ```shell
 $ curl -X POST "https://api.vhx.tv/authorizations" \
-  -d customer=https://api.vhx.tv/customers/1 \
-  -d video=https://api.vhx.tv/videos/1 \
+  -d customer="https://api.vhx.tv/customers/1" \
+  -d video="https://api.vhx.tv/videos/1" \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 

--- a/source/includes/_resource.collections.md
+++ b/source/includes/_resource.collections.md
@@ -149,7 +149,7 @@ $ curl -X POST "https://api.vhx.tv/collections" \
         <strong class="is-block text--navy">thumbnail_url</strong>
         <span class="text--transparent text-3">optional</span>
       </td>
-      <td>A publicly accessible image URL. If you prefer you can upload images directly to a collection in the VHX Publisher Admin.</td>
+      <td>A publicly accessible image URL. If you prefer, you can upload images directly to a collection in the Vimeo OTT Publisher Admin.</td>
     </tr>
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
@@ -158,11 +158,11 @@ $ curl -X POST "https://api.vhx.tv/collections" \
       </td>
       <td>
       A set of key/value pairs that you can attach to a collection object. It can be useful for
-      storing additional information about the collection in a structured format.<br><br>
-
+      storing additional information about the collection in a structured format.
+      <br><br>
       Metadata keys must be strings. There are a few reserved keys that are auto-generated, which cannot
-      be updated. For collections, the following key is reserved: <code>season_number</code><br><br>
-
+      be updated. For collections, the following key is reserved: <code>season_number</code>
+      <br><br>
       Metadata values can be strings, integers, arrays, or images. An image metadata value
       must must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>.
       </td>
@@ -175,14 +175,14 @@ $ curl -X POST "https://api.vhx.tv/collections" \
       <td>
       An array of plan types that you can use to set collection availability.
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
-      <code>standard</code>.<br><br>
-
+      <code>standard</code>.
+      <br><br>
       The <code>public</code> plan makes the collection object available without email
-      registration or paid subscription.<br><br>
-
+      registration or paid subscription.
+      <br><br>
       The <code>free</code> plan makes the collection object available for free, but requires user email
-      registration<br><br>
-
+      registration
+      <br><br>
       The <code>standard</code> plan makes the collection object available to paying subscribers.
       </td>
     </tr>
@@ -290,8 +290,8 @@ GET /collections
 
 ```shell
 $ curl -X GET -G "https://api.vhx.tv/collections" \
-  -d product=https://api.vhx.tv/products/1 \
-  -d plan=standard
+  -d product="https://api.vhx.tv/products/1" \
+  -d plan="standard" \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -459,7 +459,7 @@ $ curl -X PUT "https://api.vhx.tv/collections/1" \
 ```
 
 <section class="text-2 contain">
-  <p>No fields are required when updating a collection, however; you cannot update a collection's type once it has already been created.</p>
+  <p>No fields are required when updating a collection. Please note a collection's type cannot be updated once it has already been created.</p>
 </section>
 
 <table>
@@ -491,7 +491,7 @@ $ curl -X PUT "https://api.vhx.tv/collections/1" \
         <strong class="is-block text--navy">thumbnail_url</strong>
         <span class="text--transparent text-3">optional</span>
       </td>
-      <td>A publicly accessible image URL. If you prefer you can upload images directly to a collection in the VHX Publisher Admin.</td>
+      <td>A publicly accessible image URL. If you prefer you can upload images directly to a collection in the Vimeo OTT Publisher Admin.</td>
     </tr>
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
@@ -500,11 +500,11 @@ $ curl -X PUT "https://api.vhx.tv/collections/1" \
       </td>
       <td>
       A set of key/value pairs that you can attach to a collection object. It can be useful for
-      storing additional information about the collection in a structured format.<br><br>
-
+      storing additional information about the collection in a structured format.
+      <br><br>
       Metadata keys must be strings. There are a few reserved keys that are auto-generated, which cannot
-      be updated. For collections, the following key is reserved: <code>season_number</code><br><br>
-
+      be updated. For collections, the following key is reserved: <code>season_number</code>
+      <br><br>
       Metadata values can be strings, integers, arrays, or images. An image metadata value
       must must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>.
       </td>
@@ -517,14 +517,14 @@ $ curl -X PUT "https://api.vhx.tv/collections/1" \
       <td>
       An array of plan types that you can use to set collection availability.
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
-      <code>standard</code>.<br><br>
-
+      <code>standard</code>.
+      <br><br>
       The <code>public</code> plan makes the collection object available without email
-      registration or paid subscription.<br><br>
-
+      registration or paid subscription.
+      <br><br>
       The <code>free</code> plan makes the collection object available for free, but requires user email
-      registration<br><br>
-
+      registration
+      <br><br>
       The <code>standard</code> plan makes the collection object available to paying subscribers.
       </td>
     </tr>

--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -90,14 +90,6 @@ $ curl -X POST "https://api.vhx.tv/customers" \
     </tr>
     <tr class="text-2 border-bottom border--light-gray is-internal">
       <td class="nowrap">
-        <strong class="is-block text--navy">billing</strong>
-        <span class="is-block text--transparent text-3">object</span>
-        <span class="text--transparent text-3">optional</span>
-      </td>
-      <td>Billing parameters for <a href="/in-app-purchases">In-App Purchases</a> for the Apple, Google, and Roku platforms.</td>
-    </tr>
-    <tr class="text-2 border-bottom border--light-gray is-internal">
-      <td class="nowrap">
         <strong class="is-block text--navy">plan</strong>
         <span class="is-block text--transparent text-3">string</span>
         <span class="text--transparent text-3">optional, default is "standard"</span>
@@ -357,7 +349,7 @@ PUT /customers/:id/products
 
 ```shell
 $ curl -X PUT "https://api.vhx.tv/customers/1/products" \
-  -d product=https://api.vhx.tv/products/1 \
+  -d product="https://api.vhx.tv/products/1" \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -407,7 +399,7 @@ DELETE /customers/:id/products
 
 ```shell
 $ curl -X DELETE "https://api.vhx.tv/customers/1/products" \
-  -d product=https://api.vhx.tv/products/1 \
+  -d product="https://api.vhx.tv/products/1" \
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -457,6 +449,7 @@ GET /customers/:id/watching
 
 ```shell
 $ curl -X GET "https://api.vhx.tv/customers/1/watching" \
+  -H "VHX-Customer: https://api.vhx.tv/customers/1"
   -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:
 ```
 
@@ -493,7 +486,6 @@ $ curl -X GET "https://api.vhx.tv/customers/1/watching" \
 ```
 <section class="text-2 contain margin-bottom-medium">
   <p>Retrieves the videos currently in progress for a customer.</p>
-  <p class="is-internal text-2">For applications that are integrated via OAuth2 access tokens with our user authentication system can use the alias <code>https://api.vhx.tv/me/watching</code> when making cURL requests.</p>
 </section>
 
 <table>
@@ -511,7 +503,7 @@ $ curl -X GET "https://api.vhx.tv/customers/1/watching" \
         <span class="is-block text--transparent text-3">string</span>
         <span class="text--yellow text-3">REQUIRED</span>
       </td>
-      <td>The <code>href</code> of the customer being retrieved.</td>
+      <td>The <code>href</code> of the customer being retrieved. This needs to be provided in the request url and the <code>VHX-Customer</code> header.</td>
     </tr>
   </tbody>
 </table>
@@ -567,7 +559,6 @@ $ curl -X GET "https://api.vhx.tv/customers/1/watchlist" \
 
 <section class="text-2 contain margin-bottom-medium">
   <p>Retrieves watchlist items for a given customer.</p>
-  <p class="is-internal text-2">For applications that are integrated via OAuth2 access tokens with our user authentication system can use the alias <code>https://api.vhx.tv/me/watchlist</code> when making cURL requests.</p>
 </section>
 
 <table>
@@ -611,7 +602,6 @@ $ curl -X PUT "https://api.vhx.tv/customers/1/watchlist" \
 
 <section class="text-2 contain margin-bottom-medium">
   <p>Adds an item (a video) to a customer's watchlist.</p>
-  <p class="is-internal text-2">For applications that are integrated via OAuth2 access tokens with our user authentication system can use the alias <code>https://api.vhx.tv/me/watchlist</code> when making cURL requests.</p>
 </section>
 
 <table>
@@ -663,7 +653,6 @@ $ curl -X DELETE "https://api.vhx.tv/customers/1/watchlist" \
 
 <section class="text-2 contain margin-bottom-medium">
   <p>Removes an item (a video) from a customer's watchlist.</p>
-  <p class="is-internal text-2">For applications that are integrated via OAuth2 access tokens with our user authentication system can use the alias <code>https://api.vhx.tv/me/watchlist</code> when making cURL requests.</p>
 </section>
 
 <table>

--- a/source/includes/_resource.videos.md
+++ b/source/includes/_resource.videos.md
@@ -134,7 +134,6 @@ $ curl -X POST "https://api.vhx.tv/videos" \
       </td>
       <td>A title for the video.</p></td>
     </tr>
-
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">source_url</strong>
@@ -142,7 +141,6 @@ $ curl -X POST "https://api.vhx.tv/videos" \
       </td>
       <td>An accessible master video file per our compression settings. To grant us permission to download the video source_url from your S3 bucket, see our <a href="https://gist.github.com/ksheurs/d57e4d1857c7ef9465fb" target="_blank">S3 policy</a>.</p></td>
     </tr>
-
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">description</strong>
@@ -150,7 +148,6 @@ $ curl -X POST "https://api.vhx.tv/videos" \
       </td>
       <td>A description for the video.</p></td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">metadata</strong>
@@ -158,19 +155,18 @@ $ curl -X POST "https://api.vhx.tv/videos" \
       </td>
       <td>
       A set of key/value pairs that you can attach to a video object. It can be useful for
-      storing additional information about the video in a structured format. <br><br>
-
+      storing additional information about the video in a structured format.
+      <br><br>
       Metadata keys must be strings. There are a few reserved keys that
       are auto-generated, which cannot be updated. These reserved keys are:
       <code>advertising_keywords</code>, <code>series_name</code>,
       <code>season_name</code>, <code>season_number</code>,
-      <code>episode_number</code>, and <code>movie_name</code><br><br>
-
+      <code>episode_number</code>, and <code>movie_name</code>
+      <br><br>
       Metadata values can be strings, integers, arrays, or images. An image metadata value must
       must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>.
       </td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">plans</strong>
@@ -179,18 +175,17 @@ $ curl -X POST "https://api.vhx.tv/videos" \
       <td>
       An array of plan types that you can use to set video availability.
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
-      <code>standard</code>.<br><br>
-
+      <code>standard</code>.
+      <br><br>
       The <code>public</code> plan makes the video object available without email
-      registration or paid subscription.<br><br>
-
+      registration or paid subscription.
+      <br><br>
       The <code>free</code> plan makes the video object available for free, but requires user email
-      registration<br><br>
-
+      registration
+      <br><br>
       The <code>standard</code> plan makes the video object available to paying subscribers.
       </td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">time_available</strong>
@@ -198,7 +193,6 @@ $ curl -X POST "https://api.vhx.tv/videos" \
       </td>
       <td>ISO8601 timestamp for scheduling the video to be available in the future. </br><code>YYYY-MM-DDTHH:MM:SSZ</code></p></td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">time_unavailable</strong>
@@ -561,7 +555,7 @@ $ curl -X PUT "https://api.vhx.tv/videos/1" \
 ```
 
 <section class="text-2 contain">
-  <p>No fields are required when updating a video.</p>
+  <p>No fields are required when updating a video. While you can use this endpoint to provide a source_url for a video that does not have one yet, updating an existing one is not supported at this time.</p>
 </section>
 
 <table>
@@ -580,7 +574,6 @@ $ curl -X PUT "https://api.vhx.tv/videos/1" \
       </td>
       <td>A title for the video.</p></td>
     </tr>
-
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">description</strong>
@@ -588,7 +581,6 @@ $ curl -X PUT "https://api.vhx.tv/videos/1" \
       </td>
       <td>A description for the video.</p></td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">metadata</strong>
@@ -596,19 +588,18 @@ $ curl -X PUT "https://api.vhx.tv/videos/1" \
       </td>
       <td>
       A set of key/value pairs that you can attach to a video object. It can be useful for
-      storing additional information about the video in a structured format. <br><br>
-
+      storing additional information about the video in a structured format.
+      <br><br>
       Metadata keys must be strings. There are a few reserved keys that
       are auto-generated, which cannot be updated. These reserved keys are:
       <code>advertising_keywords</code>, <code>series_name</code>,
       <code>season_name</code>, <code>season_number</code>,
-      <code>episode_number</code>, and <code>movie_name</code><br><br>
-
+      <code>episode_number</code>, and <code>movie_name</code>
+      <br><br>
       Metadata values can be strings, integers, arrays, or images. An image metadata value must
       must be a url of an image, hosted on vhx, prefixed with the text <code>image_url:</code>.
       </td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">plans</strong>
@@ -617,18 +608,17 @@ $ curl -X PUT "https://api.vhx.tv/videos/1" \
       <td>
       An array of plan types that you can use to set video availability.
       Values can be one or more of the following strings: <code>public</code>, <code>free</code>,
-      <code>standard</code>.<br><br>
-
+      <code>standard</code>.
+      <br><br>
       The <code>public</code> plan makes the video object available without email
-      registration or paid subscription.<br><br>
-
+      registration or paid subscription.
+      <br><br>
       The <code>free</code> plan makes the video object available for free, but requires user email
-      registration<br><br>
-
+      registration
+      <br><br>
       The <code>standard</code> plan makes the video object available to paying subscribers.
       </td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">time_available</strong>
@@ -636,7 +626,6 @@ $ curl -X PUT "https://api.vhx.tv/videos/1" \
       </td>
       <td>ISO8601 timestamp for scheduling the video to be available in the future. </br><code>YYYY-MM-DDTHH:MM:SSZ</code></p></td>
     </tr>
-
     <tr class="is-internal text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">time_unavailable</strong>

--- a/source/javascripts/examples/_analytics.js
+++ b/source/javascripts/examples/_analytics.js
@@ -3,10 +3,7 @@
   window.data.analytics = {
     income: {
       client_statement: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=income_statement\n  -d from=2016-10-01 \\\n  -d to=today\\\n -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'income_statment',\n  from: '2016-10-01',\n  to: 'today'\n})",
-        node: "vhx.analytics.report({\n  type: 'income_statment',\n  from: '2016-10-01',\n  to: 'today'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'income_statement',\n  'from' => '2016-10-01',\n  'to' => 'today'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=income_statement \\\n  -d from=2016-10-01 \\\n  -d to=today \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       statement: {
         "_links": {
@@ -84,10 +81,7 @@
     },
     traffic: {
       client_aggregate: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=traffic\n  -d from=1-month-ago \\\n  -d to=today \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'traffic',\n  from: '1-month-ago',\n  to: 'today'\n})",
-        node: "vhx.analytics.report({\n  type: 'traffic',\n  from: '1-month-ago',\n  to: 'today'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'traffic',\n  'from' => '1-month-ago',\n  'to' => 'today'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=traffic \\\n  -d from=1-month-ago \\\n  -d to=today \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       aggregate: {
         "_links": {
@@ -211,10 +205,7 @@
     },
     units: {
       client_timeSeries: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=units\n  -d from=2013-07-19 \\\n  -d to=2013-07-20 \\\n  -d by=day \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'units',\n  from: '2013-07-19',\n  to: '2013-07-20'\n  by: 'day'\n})",
-        node: "vhx.analytics.report({\n  type: 'units',\n  from: '2013-07-19',\n  to: '2013-07-20'\n  by: 'day'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'units',\n  'from' => '2013-07-19',\n  'to' => '2013-07-20'\n  'by' => 'day'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=units \\\n  -d from=2013-07-19 \\\n  -d to=2013-07-20 \\\n  -d by=day \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       timeSeries: {
         "_links": {
@@ -476,10 +467,7 @@
         "page": 1
       },
       client_aggregate: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=units\n  -d from=2013-07-19 \\\n  -d to=2013-07-20 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'units',\n  from: '2013-07-19',\n  to: '2013-07-20'\n})",
-        node: "vhx.analytics.report({\n  type: 'units',\n  from: '2013-07-19',\n  to: '2013-07-20'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'units',\n  'from' => '2013-07-19',\n  'to' => '2013-07-20'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=units \\\n  -d from=2013-07-19 \\\n  -d to=2013-07-20 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       aggregate: {
         "_links": {
@@ -618,10 +606,7 @@
     },
     subscribers: {
       client_aggregate: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=subscribers\n  -d from=2015-08-28 \\\n  -d to=2015-11-28 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'subscribers',\n  from: '2015-08-28',\n  to: '2015-11-28'\n})",
-        node: "vhx.analytics.report({\n  type: 'subscribers',\n  from: '2015-08-28',\n  to: '2015-11-28'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'subscribers',\n  'from' => '2015-08-28',\n  'to' => '2015-11-28'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=subscribers \\\n  -d from=2015-08-28 \\\n  -d to=2015-11-28 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       aggregate: {
         "_links": {
@@ -642,10 +627,7 @@
         "page": 1
       },
       client_timeSeries: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=units\n  -d from=2015-07-01 \\\n  -d to=2015-09-30 \\\n  -d by=month \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'units',\n  from: '2015-07-01',\n  to: '2015-09-30'\n  by: 'month'\n})",
-        node: "vhx.analytics.report({\n  type: 'units',\n  from: '2015-07-01',\n  to: '2015-09-30'\n  by: 'month'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'units',\n  'from' => '2015-07-01',\n  'to' => '2015-09-30'\n  'by' => 'month'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=subscribers \\\n  -d from=2015-07-01 \\\n  -d to=2015-09-30 \\\n  -d by=month \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       timeSeries: {
         "_links": {
@@ -723,10 +705,7 @@
     },
     churn: {
       client_aggregate: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=churn\n  -d from=2016-07-28 \\\n  -d to=2016-10-28 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'churn',\n  from: '2016-07-28',\n  to: '2016-10-28'\n})",
-        node: "vhx.analytics.report({\n  type: 'churn',\n  from: '2016-07-28',\n  to: '2016-10-28'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'churn',\n  'from' => '2016-07-28',\n  'to' => '2016-10-28'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=churn \\\n  -d from=2016-07-28 \\\n  -d to=2016-10-28 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       aggregate: {
         "_links": {
@@ -785,10 +764,7 @@
         "page": 1
       },
       client_timeSeries: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=churn\n  -d from=2016-09-28 \\\n  -d to=2016-10-28 \\\n  -d by=month \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'churn',\n  from: '2016-09-28',\n  to: '2016-10-28'\n  by: 'month'\n})",
-        node: "vhx.analytics.report({\n  type: 'churn',\n  from: '2016-09-28',\n  to: '2016-10-28'\n  by: 'month'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'churn',\n  'from' => '2016-09-28',\n  'to' => '2016-10-28'\n  'by' => 'month'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=churn \\\n  -d from=2016-09-28 \\\n  -d to=2016-10-28 \\\n  -d by=month \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       timeSeries: {
         "_links": {
@@ -875,10 +851,7 @@
     },
     video: {
       client_aggregate: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=video\n  -d video_id=1 \\\n  -d from=2013-03-05 \\\n  -d to=2016-10-28 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'video',\n  video_id: '1',\n  from: '2013-03-05',\n  to: '2016-10-28'\n})",
-        node: "vhx.analytics.report({\n  type: 'video',\n  video_id: '1',\n  from: '2013-03-05',\n  to: '2016-10-28'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'video',\n  'videos_id' => '1',\n  'from' => '2013-03-05',\n  'to' => '2016-10-28'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=video \\\n  -d video_id=1 \\\n  -d from=2013-03-05 \\\n  -d to=2016-10-28 \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       aggregate: {
         "_links": {
@@ -900,10 +873,7 @@
         "page": 1
       },
       client_timeSeries: {
-        curl: '$ curl -X GET "https://api.vhx.tv/analytics" \\\n  -d type=video\n  -d video_id=1 \\\n  -d from=2013-03-05 \\\n  -d to=2016-10-28 \\\n  -d by=day \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
-        ruby: "video = Vhx::Analytics.report({\n  type: 'video',\n  video_id: '1',\n  from: '2013-03-05',\n  to: '2016-10-28'\n  by: 'day'\n})",
-        node: "vhx.analytics.report({\n  type: 'video',\n  video_id: '1',\n  from: '2013-03-05',\n  to: '2016-10-28'\n  by: 'day'\n}, function(err, report) {\n  // asynchronously called\n});",
-        php: "$report = \\VHX\\Analytics::report(array(\n  'type' => 'video',\n  'videos_id' => '1',\n  'from' => '2013-03-05',\n  'to' => '2016-10-28',\n  'by' => 'day'\n));",
+        curl: '$ curl -X GET -G "https://api.vhx.tv/analytics" \\\n  -d type=video \\\n  -d video_id=1 \\\n  -d from=2013-03-05 \\\n  -d to=2016-10-28 \\\n  -d by=day \\\n  -u o3g_4jLU-rxHpc9rsoh3DHfpsq1L6oyM:',
       },
       timeSeries: {
         "_links": {


### PR DESCRIPTION
Cleans up the existing resource's content and example code snippets.

<img width="1437" alt="Screen Shot 2020-02-27 at 5 16 06 PM" src="https://user-images.githubusercontent.com/9995915/75492434-c80c6780-5985-11ea-9ea6-52cf51e003fa.png">


Change log
- Cleanup syntax in some of the markdown files that was leading to weird results in the linter.
- Remove some additional references to VHX in favor of Vimeo OTT
- Ensure that code snippets have strings in quotes
- Remove client library examples for analytics js
- Clarify what analytic reports are actually available
- Other minor content updates