### PR TITLE
Remove Demo from Navbar

### DIFF
--- a/source/layouts/_header.erb
+++ b/source/layouts/_header.erb
@@ -14,7 +14,6 @@
       <li><a class="head-5" href="/player">Player</a></li>
       <li><a class="head-5" href="/integrations">Integrations</a></li>
       <li><a class="head-5 active" href="/docs/api/">API Reference</a></li>
-      <li><a class="head-5" href="http://wintergarten.io" target="_blank">Demo</a></li>
       <li><a class="btn-teal btn--brandon" href="https://www.vhx.tv/signup?survey_sale_type=fulfillment&ref=dev">Sign up</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
[OTTSUP-1892](https://vimean.atlassian.net/browse/OTTSUP-1892)

I missed this link in the process of archiving the Wintergarten site back in October 2020.