### PR TITLE
OTTAPI-2105: Update customers index status documentation

### DIFF
--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -291,6 +291,16 @@ $ curl -X GET -G "https://api.vhx.tv/customers" \
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
       <td>
+        <strong class="is-block text--navy">status</strong>
+        <span class="is-block text--transparent text-3">string</span>
+        <span class="text--transparent text-3">optional</span>
+      </td>
+      <td>
+        The status should be set to <code>all</code> when using the query search param in order to get all customers otherwise the default is <code>enabled</code>. Options are <code>all</code>, <code>enabled</code>, <code>disabled</code>, <code>cancelled</code>, <code>refunded</code>, <code>expired</code>, or <code>paused</code>
+      </td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
         <strong class="is-block text--navy">page</strong>
         <span class="is-block text--transparent text-3">integer</span>
         <span class="text--transparent text-3">optional, default is 1</span>

--- a/source/includes/_resource.customers.md
+++ b/source/includes/_resource.customers.md
@@ -279,7 +279,7 @@ $ curl -X GET -G "https://api.vhx.tv/customers" \
         <span class="is-block text--transparent text-3">string</span>
         <span class="text--transparent text-3">optional</span>
       </td>
-      <td>The query to search and filter the paginated results.</td>
+      <td>The query to search and filter the paginated results. By default filters for customers with status of <code>enabled</code> (subscribed). The status query param should be explicitly set in order to include customers that are not <code>enabled</code>. See status below.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
       <td>
@@ -296,7 +296,7 @@ $ curl -X GET -G "https://api.vhx.tv/customers" \
         <span class="text--transparent text-3">optional</span>
       </td>
       <td>
-        The status should be set to <code>all</code> when using the query search param in order to get all customers otherwise the default is <code>enabled</code>. Options are <code>all</code>, <code>enabled</code>, <code>disabled</code>, <code>cancelled</code>, <code>refunded</code>, <code>expired</code>, or <code>paused</code>
+        The status indicates the subscription status of the customer. Options are <code>enabled</code>, <code>disabled</code>, <code>cancelled</code>, <code>refunded</code>, <code>expired</code>, <code>paused</code>, or <code>all</code> (includes all statuses).
       </td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">


### PR DESCRIPTION
Issue: OTTAPI-2105

This PR updates the customers index to include the status query param. There are updates to the `query` and `status` fields shown below.

![customers-list-documentation](https://user-images.githubusercontent.com/36646528/145644877-14e6348c-67e5-49ee-9af3-b6a45cbb7ef2.jpg)
