### PR TITLE
OTTDEV-594: Update docs for comments

### DIFF
--- a/source/includes/_resource.comments.md
+++ b/source/includes/_resource.comments.md
@@ -200,7 +200,7 @@ $ curl -X GET -G "https://api.vhx.tv/comments" \
 ```
 
 <section class="text-2 contain">
-  <p>Retrieves all comments for a given video.</p>
+  <p>Retrieves all comments for the site, newest first. When the video param is provided, retrieves comments for that video.</p>
 </section>
 
 <table>
@@ -215,12 +215,38 @@ $ curl -X GET -G "https://api.vhx.tv/comments" \
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">video</strong>
-        <span class="text--yellow text-3">REQUIRED</span>
+        <span class="text--yellow text-3">optional</span>
         <span class="text--transparent text-3">href</span>
       </td>
       <td>
         The <code>href</code> of a video.
       </td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">flagged</strong>
+        <span class="text--yellow text-3">optional</span>
+        <span class="text--transparent text-3">boolean</span>
+      </td>
+      <td>
+        When set to true, returns only comments that have been reported.
+      </td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">page</strong>
+        <span class="is-block text--transparent text-3">integer</span>
+        <span class="text--transparent text-3">optional, default is 1</span>
+      </td>
+      <td>The page number of the paginated result.</td>
+    </tr>
+    <tr class="text-2 border-bottom border--light-gray">
+      <td>
+        <strong class="is-block text--navy">per_page</strong>
+        <span class="is-block text--transparent text-3">integer</span>
+        <span class="text--transparent text-3">optional, default is 25</span>
+      </td>
+      <td>The page size of the paginated result.</td>
     </tr>
   </tbody>
 </table>

--- a/source/includes/_resource.comments.md
+++ b/source/includes/_resource.comments.md
@@ -215,7 +215,7 @@ $ curl -X GET -G "https://api.vhx.tv/comments" \
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">video</strong>
-        <span class="text--yellow text-3">optional</span>
+        <span class="text--transparent text-3">optional</span>
         <span class="text--transparent text-3">href</span>
       </td>
       <td>
@@ -225,26 +225,26 @@ $ curl -X GET -G "https://api.vhx.tv/comments" \
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">flagged</strong>
-        <span class="text--yellow text-3">optional</span>
+        <span class="text--transparent text-3">optional</span>
         <span class="text--transparent text-3">boolean</span>
       </td>
       <td>
-        When set to true, returns only comments that have been reported.
+        When set to true, returns only comments that have been reported. Accepted values are <code>true</code> and <code>false</code>.
       </td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">page</strong>
-        <span class="is-block text--transparent text-3">integer</span>
-        <span class="text--transparent text-3">optional, default is 1</span>
+        <span class="text--transparent text-3">optional</span>
+        <span class="is-block text--transparent text-3">integer, default is 1</span>
       </td>
       <td>The page number of the paginated result.</td>
     </tr>
     <tr class="text-2 border-bottom border--light-gray">
       <td>
         <strong class="is-block text--navy">per_page</strong>
-        <span class="is-block text--transparent text-3">integer</span>
-        <span class="text--transparent text-3">optional, default is 25</span>
+        <span class="text--transparent text-3">optional</span>
+        <span class="is-block text--transparent text-3">integer, default is 25</span>
       </td>
       <td>The page size of the paginated result.</td>
     </tr>


### PR DESCRIPTION
Issue: [OTTDEV-594](https://vimean.atlassian.net/browse/OTTDEV-594)

With https://github.com/vhx/crystal/pull/20256, we will stop requiring a `video` param, and explicitly support `GET /comments` returning all of a site's comments.

Changes:
- changing `video` param to optional
- adding docs for `page`, `per_page`, and `flagged` params (already supported)
- updating description

---
<img width="800" alt="Screen Shot 2023-04-19 at 7 48 12 PM" src="https://user-images.githubusercontent.com/5272416/233223133-007bd1fb-9ae5-4c5b-a4fa-3614ba8f0c8a.png">



[OTTDEV-594]: https://vimean.atlassian.net/browse/OTTDEV-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ