### PR TITLE
Add `include_events` param to collections#list_all_items

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -3385,6 +3385,21 @@ id="videos-delete">Delete a Video</h3>
       </tr>
       <tr class="text-2 border-bottom border--light-gray">
         <td>
+          <strong class="is-block text--navy">include_events</strong>
+          <span class="is-block text--transparent text-3">integer</span>
+          <span class="text--transparent text-3">optional</span>
+        </td>
+        <td>
+          <p>Determines whether to include Vimeo events in the response.</p>
+          <ul>
+            <li><code>1</code>: Include events.</li>
+            <li><code>0</code>: Exclude events.</li>
+          </ul>
+          <p>Vimeo events are excluded if you omit this parameter.</p>
+        </td>
+      </tr>
+      <tr class="text-2 border-bottom border--light-gray">
+        <td>
           <strong class="is-block text--navy">sort</strong>
           <span class="is-block text--transparent text-3">string</span>
           <span class="text--transparent text-3">optional</span>


### PR DESCRIPTION
## Summary

Be default, Vimeo events are excluded from the `collections#list_all_items` endpoint. They can be included by providing the `include_events=1` param. Let's add it to the documentation.

## Demo

![CleanShot 2025-01-21 at 17 58 51@2x](https://github.com/user-attachments/assets/c98154bc-063e-485c-83ff-8812a95801d0)